### PR TITLE
Added Dockerfile to build in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential libcurl3-dev libopencv-dev libopencv-core-dev python-pip software-properties-common \
+ && add-apt-repository ppa:maarten-fonville/protobuf \
+ && apt-get update \
+ && apt-get install -y protobuf-compiler libprotobuf-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN pip install setuptools \
+ && pip install pillow
+
+WORKDIR /workspace
+COPY . .
+RUN make -f Makefile.clients all pip \
+ && pip install --no-cache-dir --upgrade build/dist/dist/inference_server-1.0.0-cp27-cp27mu-linux_x86_64.whl
+


### PR DESCRIPTION
Adding a Dockerfile to simplify the client build.

I hit an error on `make -f Makefile.clients all pip` step.

```(cd build/dist && python setup.py bdist_wheel)
Traceback (most recent call last):
  File "setup.py", line 60, in <module>
    cmdclass={'bdist_wheel': bdist_wheel},
  File "/usr/local/lib/python2.7/dist-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 137, in setup
    ok = dist.parse_command_line()
  File "/usr/local/lib/python2.7/dist-packages/setuptools/dist.py", line 500, in parse_command_line
    result = _Distribution.parse_command_line(self)
  File "/usr/lib/python2.7/distutils/dist.py", line 467, in parse_command_line
    args = self._parse_command_opts(parser, args)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/dist.py", line 815, in _parse_command_opts
    nargs = _Distribution._parse_command_opts(self, parser, args)
  File "/usr/lib/python2.7/distutils/dist.py", line 529, in _parse_command_opts
    if not issubclass(cmd_class, Command):
TypeError: issubclass() arg 1 must be a class
Makefile.clients:85: recipe for target 'pip' failed
make: *** [pip] Error 1
The command '/bin/sh -c make -f Makefile.clients all pip  && pip install --no-cache-dir --upgrade build/dist/dist/inference_server-1.0.0-cp27-cp27mu-linux_x86_64.whl' returned a non-zero code: 2```