### PR TITLE
Relative imports in the proto API

### DIFF
--- a/Makefile.clients
+++ b/Makefile.clients
@@ -151,7 +151,6 @@ $(GRPC_OBJS): $(GRPC_SRCS) $(GRPC_HDRS)
 $(BUILDDIR)/$(SRCDIR)/%.proto: $(SRCDIR)/%.proto
 	mkdir -p $(dir $@)
 	cp $< $@
-	sed -i -e 's/src\/core\///' $@
 
 $(BUILDDIR)/$(SRCDIR)/%.pb.cc $(BUILDDIR)/$(SRCDIR)/%.pb.h \
     $(BUILDDIR)/$(SRCDIR)/%_pb2.py: $(BUILDDIR)/$(SRCDIR)/%.proto $(LIBGRPCDIR)/libgrpc_indicator

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -28,9 +28,9 @@ syntax = "proto3";
 
 package nvidia.inferenceserver;
 
-import "src/core/api.proto";
-import "src/core/request_status.proto";
-import "src/core/server_status.proto";
+import "api.proto";
+import "request_status.proto";
+import "server_status.proto";
 
 service GRPCService {
   // Get server or model status

--- a/src/core/server_status.proto
+++ b/src/core/server_status.proto
@@ -28,7 +28,7 @@ syntax = "proto3";
 
 package nvidia.inferenceserver;
 
-import "src/core/model_config.proto";
+import "model_config.proto";
 
 // Statistic collecting a duration metric
 message StatDuration {


### PR DESCRIPTION
Relaxed the absolute import paths in the .protos to simplify integrating the API in custom clients.